### PR TITLE
Fix alignment for full-width characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3167,6 +3167,7 @@ dependencies = [
  "rusqlite",
  "tempfile",
  "tui-input",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ anyhow = "1.0.95"
 fuzzy-matcher = "0.3.7"
 tui-input = "0.11.1"
 home = "0.5.11"
+unicode-width = "0.2.0"
 
 [build-dependencies]
 clap = { version = "4.5.29", features = ["derive"] }

--- a/src/utils/polars_ext.rs
+++ b/src/utils/polars_ext.rs
@@ -4,6 +4,7 @@ use polars::{
     prelude::{AnyValue, DataType},
     series::{ChunkCompareEq, Series},
 };
+use unicode_width::UnicodeWidthStr;
 
 use crate::tui::sheet::SheetSection;
 
@@ -82,12 +83,12 @@ fn series_width(series: &Series) -> usize {
                 .into_string()
                 .lines()
                 .next()
-                .map(str::len)
+                .map(|s| s.width())
                 .unwrap_or(0)
         })
         .max()
         .unwrap_or_default()
-        .max(series.name().len())
+        .max(series.name().as_str().width())
 }
 
 impl FuzzyCmp for AnyValue<'_> {


### PR DESCRIPTION
Hello, I find `Tabiew` alignment are incorrect when working with CJK characters, and this PR try to fix it.

Anyway, thanks for your great software.

## Sample Data

`sample.csv`

```csv
證券代號,證券名稱,成交股數,成交金額,開盤價,最高價,最低價,收盤價,漲跌價差,成交筆數
"0050","元大台灣50","26452171","5136323011","195.15","195.15","193.50","194.00","-2.3500","69782"
"0051","元大中型100","72289","5653437","78.00","78.40","78.00","78.40","0.2000","378"
"0052","富邦科技","1413420","274054143","194.55","194.60","193.35","193.65","-2.8500","3294"
"0053","元大電子","16788","1741306","104.00","104.00","103.25","103.40","-1.5000","117"
"0055","元大MSCI金融","135813","3920376","28.88","28.90","28.85","28.86","-0.0200","218"
"0056","元大高股息","19975845","725165012","36.35","36.36","36.24","36.29","-0.0500","15020"
"0057","富邦摩台","25178","3640427","144.85","144.85","144.20","144.20","-1.8500","104"
"0061","元大寶滬深","352737","6866689","19.46","19.55","19.36","19.54","0.0500","270"
"006203","元大MSCI台灣","11514","1040566","90.45","90.55","90.00","90.15","-0.9000","111"
"006204","永豐臺灣加權","4599","531678","115.70","115.70","115.60","115.65","-0.9000","96"
"006205","富邦上証","198644","6586029","33.10","33.28","32.96","33.20","0.1000","207"
"006206","元大上證50","116662","3650006","31.23","31.46","31.15","31.42","0.1700","103"
"006207","復華滬深","129215","3283887","25.34","25.47","25.23","25.41","0.0700","94"
"006208","富邦台50","22118272","2524931484","114.75","114.80","113.90","114.00","-1.3500","50632"
```

## Before Fix

![Image](https://github.com/user-attachments/assets/9deb17d1-1d09-4ba5-b0a0-66355ccf007f)

## After Fix

![fixed-2](https://github.com/user-attachments/assets/cdc517b3-5027-4d4c-a88c-3ab987e1b04e)

