### PR TITLE
Add vi-compatible ^ for scroll all the way to the left

### DIFF
--- a/src/handler/key.rs
+++ b/src/handler/key.rs
@@ -285,7 +285,12 @@ impl Default for KeyHandler {
                     .code(KeyCode::PageDown)
                     .action(AppAction::TableGoDownFullPage),
             )
-            // _ $
+            // ^_ $ line beginning end
+            .add(
+                Keybind::default()
+                    .char('^')
+                    .action(AppAction::TableScrollStart),
+            )
             .add(
                 Keybind::default()
                     .char('_')


### PR DESCRIPTION
Tabiew supports most vi movement keys so I keep wanting to use `^` to go to beginning of line.

I think most people who are used to vim will also expect this (or `0`) to work.