### PR TITLE
display help message when run with no arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ fn main() {
 
         // Show help message if no arguments are given and stdin is not piped
         if args_os.len() == 1 && std::io::stdin().is_terminal() {
-            return Ok(Args::command().print_help()?);
+            return Args::command().print_help().unwrap_or_graceful_shutdown();
         } else {
             Args::parse_from(args_os)
         }


### PR DESCRIPTION
Display help message when run with no arguments.

Currently, `tw` waits for stdin if no arguments are provided. This change aligns its behavior with common CLI tools.

Would close  #70.