### PR TITLE
Make `Q` quit the application

### DIFF
--- a/src/handler/action.rs
+++ b/src/handler/action.rs
@@ -32,7 +32,6 @@ use super::command::{commands_help_data_frame, parse_into_action};
 #[derive(Debug, Clone)]
 pub enum AppAction {
     NoAction,
-    QuitAll,
     ToggleBorders,
     DismissError,
     DismissErrorAndShowPalette,
@@ -392,10 +391,6 @@ pub fn execute(action: AppAction, app: &mut App) -> AppResult<Option<AppAction>>
                 app.tabs_mut().remove(idx);
                 Ok(Some(AppAction::TabSelect(idx)))
             }
-        }
-        AppAction::QuitAll => {
-            app.quit();
-            Ok(None)
         }
         AppAction::ExportDsv {
             destination,

--- a/src/handler/key.rs
+++ b/src/handler/key.rs
@@ -186,7 +186,7 @@ impl Default for KeyHandler {
             .add(
                 Keybind::default()
                     .char('Q')
-                    .action(AppAction::QuitAll),
+                    .action(AppAction::Quit),
             )
             // q
             .add(
@@ -589,7 +589,7 @@ impl Default for KeyHandler {
                     .code(KeyCode::Enter)
                     .action(AppAction::TabPanelSelect),
             )
-            .add(Keybind::default().char('Q').action(AppAction::QuitAll))
+            .add(Keybind::default().char('Q').action(AppAction::Quit))
             .add(Keybind::default().char('q').action(AppAction::TabHidePanel))
             .add(
                 Keybind::default()


### PR DESCRIPTION
When you have multiple tabs open, e.g. when looking at a sqlite file with multiple tables or a list of '*' files I find that I need to `q` each tab separately and I wanted a way to quit all tabs and exit. 

This PR adds `Q` to quit the app even if multiple tabs are open.