### PR TITLE
Fix Ctrl-f shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ curl -s "https://raw.githubusercontent.com/wiki/shshemi/tabiew/housing.csv" | tw
 | `b` / `w` | Previous / next column|
 | `e` | Toggle Auto-Fit|
 | `Ctrl + u` / `Ctrl + d`| Move half page up/down|
+| `Ctrl + b` / `Ctrl + f`| Move full page up/down|
 | `Home` or `g`| Move to first row|
 | `End` or `G`| Move to last row|
 | `Ctrl + r`| Reset data frame|

--- a/src/handler/key.rs
+++ b/src/handler/key.rs
@@ -291,7 +291,7 @@ impl Default for KeyHandler {
             )
             .add(
                 Keybind::default()
-                    .char('d')
+                    .char('f')
                     .ctrl()
                     .action(AppAction::TableGoDownFullPage),
             )


### PR DESCRIPTION
`TableGoDownFullPage` was incorrectly mapped to `Ctrl-d` instead of `Ctrl-f`