### PR TITLE
Add --max-rows flag to cap rows loaded from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ tw data.txt -f tsv
 tw data.txt -f dsv --separator '|'
 ```
 
+Preview only the first rows of a large file:
+```bash
+tw big.csv --max-rows 1000
+```
+`--max-rows` is handy for sanity-checking the schema and a sample of the data before loading a multi-GB file. It applies to CSV/DSV/TSV, Parquet, JSON, JSON Lines, Arrow, and Avro.
+
 Open a URL using curl:
 ```bash
 curl -s "https://raw.githubusercontent.com/wiki/shshemi/tabiew/housing.csv" | tw

--- a/src/args.rs
+++ b/src/args.rs
@@ -118,6 +118,13 @@ pub struct Args {
         default_value_t = false
     )]
     pub no_type_inference: bool,
+
+    #[arg(
+        long,
+        help = "Limits the number of rows read from the input. Applies to CSV/DSV/TSV, Parquet, JSON, JSON Lines, Arrow, and Avro files.",
+        required = false
+    )]
+    pub max_rows: Option<usize>,
 }
 
 #[derive(Debug, Clone, ValueEnum)]

--- a/src/io/reader/arrow.rs
+++ b/src/io/reader/arrow.rs
@@ -4,20 +4,35 @@ use polars::{io::SerReader, prelude::IpcReader};
 
 use crate::{
     AppResult,
+    args::Args,
     io::reader::{DataFrameReader, NamedFrames, ReaderSource},
     misc::stdin::stdin,
 };
 
-#[derive(Debug)]
-pub struct ArrowIpcToDataFrame;
+#[derive(Debug, Default)]
+pub struct ArrowIpcToDataFrame {
+    max_rows: Option<usize>,
+}
+
+impl ArrowIpcToDataFrame {
+    pub fn from_args(args: &Args) -> Self {
+        Self {
+            max_rows: args.max_rows,
+        }
+    }
+}
 
 impl DataFrameReader for ArrowIpcToDataFrame {
     fn read_to_data_frames(&self, input: ReaderSource) -> AppResult<NamedFrames> {
         let df = match &input {
             ReaderSource::File(path) => IpcReader::new(File::open(path)?)
+                .with_n_rows(self.max_rows)
                 .set_rechunk(true)
                 .finish()?,
-            ReaderSource::Stdin => IpcReader::new(stdin()).set_rechunk(true).finish()?,
+            ReaderSource::Stdin => IpcReader::new(stdin())
+                .with_n_rows(self.max_rows)
+                .set_rechunk(true)
+                .finish()?,
         };
         Ok([(input.table_name(), df)].into())
     }

--- a/src/io/reader/avro.rs
+++ b/src/io/reader/avro.rs
@@ -4,20 +4,35 @@ use polars::io::{SerReader, avro::AvroReader};
 
 use crate::{
     AppResult,
+    args::Args,
     io::reader::{DataFrameReader, NamedFrames, ReaderSource},
     misc::stdin::stdin,
 };
 
-#[derive(Debug)]
-pub struct AvroToDataFrame;
+#[derive(Debug, Default)]
+pub struct AvroToDataFrame {
+    max_rows: Option<usize>,
+}
+
+impl AvroToDataFrame {
+    pub fn from_args(args: &Args) -> Self {
+        Self {
+            max_rows: args.max_rows,
+        }
+    }
+}
 
 impl DataFrameReader for AvroToDataFrame {
     fn read_to_data_frames(&self, input: ReaderSource) -> AppResult<NamedFrames> {
         let df = match &input {
             ReaderSource::File(path) => AvroReader::new(File::open(path)?)
+                .with_n_rows(self.max_rows)
                 .set_rechunk(true)
                 .finish()?,
-            ReaderSource::Stdin => AvroReader::new(stdin()).set_rechunk(true).finish()?,
+            ReaderSource::Stdin => AvroReader::new(stdin())
+                .with_n_rows(self.max_rows)
+                .set_rechunk(true)
+                .finish()?,
         };
         Ok([(input.table_name(), df)].into())
     }

--- a/src/io/reader/csv.rs
+++ b/src/io/reader/csv.rs
@@ -22,6 +22,7 @@ pub struct CsvToDataFrame {
     no_header: bool,
     ignore_errors: bool,
     truncate_ragged_lines: bool,
+    max_rows: Option<usize>,
 }
 
 impl CsvToDataFrame {
@@ -33,6 +34,7 @@ impl CsvToDataFrame {
             no_header: args.no_header,
             ignore_errors: args.ignore_errors,
             truncate_ragged_lines: args.truncate_ragged_lines,
+            max_rows: args.max_rows,
         }
     }
 
@@ -56,6 +58,7 @@ impl CsvToDataFrame {
             .with_ignore_errors(self.ignore_errors)
             .with_infer_schema_length(self.infer_schema.to_csv_infer_schema_length())
             .with_has_header(!self.no_header)
+            .with_n_rows(self.max_rows)
             .with_parse_options(
                 CsvParseOptions::default()
                     .with_truncate_ragged_lines(self.truncate_ragged_lines)
@@ -82,6 +85,7 @@ impl Default for CsvToDataFrame {
             no_header: false,
             ignore_errors: true,
             truncate_ragged_lines: false,
+            max_rows: None,
         }
     }
 }
@@ -93,5 +97,41 @@ impl DataFrameReader for CsvToDataFrame {
             ReaderSource::Stdin => self.try_into_frame(stdin()),
         }?;
         Ok([(input.table_name(), df)].into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+
+    const CSV: &[u8] = b"a,b\n1,2\n3,4\n5,6\n7,8\n";
+
+    #[test]
+    fn reads_every_row_without_a_cap() {
+        let reader = CsvToDataFrame::default();
+        let df = reader.try_into_frame(Cursor::new(CSV.to_vec())).unwrap();
+        assert_eq!(df.height(), 4);
+    }
+
+    #[test]
+    fn caps_rows_when_max_rows_is_set() {
+        let reader = CsvToDataFrame {
+            max_rows: Some(2),
+            ..Default::default()
+        };
+        let df = reader.try_into_frame(Cursor::new(CSV.to_vec())).unwrap();
+        assert_eq!(df.height(), 2);
+    }
+
+    #[test]
+    fn max_rows_larger_than_the_file_keeps_every_row() {
+        let reader = CsvToDataFrame {
+            max_rows: Some(100),
+            ..Default::default()
+        };
+        let df = reader.try_into_frame(Cursor::new(CSV.to_vec())).unwrap();
+        assert_eq!(df.height(), 4);
     }
 }

--- a/src/io/reader/json.rs
+++ b/src/io/reader/json.rs
@@ -15,12 +15,14 @@ use crate::{
 #[derive(Debug)]
 pub struct JsonToDataFrame {
     ignore_errors: bool,
+    max_rows: Option<usize>,
 }
 
 impl JsonToDataFrame {
     pub fn from_args(args: &Args) -> Self {
         Self {
             ignore_errors: args.ignore_errors,
+            max_rows: args.max_rows,
         }
     }
 }
@@ -29,6 +31,7 @@ impl Default for JsonToDataFrame {
     fn default() -> Self {
         Self {
             ignore_errors: true,
+            max_rows: None,
         }
     }
 }
@@ -47,6 +50,8 @@ impl DataFrameReader for JsonToDataFrame {
                 .with_ignore_errors(self.ignore_errors)
                 .finish()?,
         };
+        // JsonReader has no native row limit, so cap the frame after reading.
+        let df = df.head(self.max_rows);
         Ok([(input.table_name(), df)].into())
     }
 }

--- a/src/io/reader/json_line.rs
+++ b/src/io/reader/json_line.rs
@@ -18,12 +18,14 @@ use crate::{
 #[derive(Debug)]
 pub struct JsonLineToDataFrame {
     ignore_errors: bool,
+    max_rows: Option<usize>,
 }
 
 impl JsonLineToDataFrame {
     pub fn from_args(args: &Args) -> Self {
         Self {
             ignore_errors: args.ignore_errors,
+            max_rows: args.max_rows,
         }
     }
 }
@@ -32,6 +34,7 @@ impl Default for JsonLineToDataFrame {
     fn default() -> Self {
         Self {
             ignore_errors: true,
+            max_rows: None,
         }
     }
 }
@@ -52,6 +55,8 @@ impl DataFrameReader for JsonLineToDataFrame {
                 .set_rechunk(true)
                 .finish()?,
         };
+        // JsonReader has no native row limit, so cap the frame after reading.
+        let df = df.head(self.max_rows);
         Ok([(input.table_name(), df)].into())
     }
 }

--- a/src/io/reader/parquet.rs
+++ b/src/io/reader/parquet.rs
@@ -4,21 +4,40 @@ use polars::{io::SerReader, prelude::ParquetReader};
 
 use crate::{
     AppResult,
+    args::Args,
     io::reader::{DataFrameReader, NamedFrames, ReaderSource},
     misc::stdin::stdin,
 };
 
-#[derive(Debug)]
-pub struct ParquetToDataFrame;
+#[derive(Debug, Default)]
+pub struct ParquetToDataFrame {
+    max_rows: Option<usize>,
+}
+
+impl ParquetToDataFrame {
+    pub fn from_args(args: &Args) -> Self {
+        Self {
+            max_rows: args.max_rows,
+        }
+    }
+
+    fn slice(&self) -> Option<(usize, usize)> {
+        self.max_rows.map(|n| (0, n))
+    }
+}
 
 impl DataFrameReader for ParquetToDataFrame {
     fn read_to_data_frames(&self, input: ReaderSource) -> AppResult<NamedFrames> {
         let df = match &input {
             ReaderSource::File(path) => ParquetReader::new(File::open(path)?)
+                .with_slice(self.slice())
                 .set_rechunk(true)
                 .finish()?,
 
-            ReaderSource::Stdin => ParquetReader::new(stdin()).set_rechunk(true).finish()?,
+            ReaderSource::Stdin => ParquetReader::new(stdin())
+                .with_slice(self.slice())
+                .set_rechunk(true)
+                .finish()?,
         };
         Ok([(input.table_name(), df)].into())
     }

--- a/src/io/reader/traits.rs
+++ b/src/io/reader/traits.rs
@@ -33,15 +33,15 @@ impl BuildReader for Args {
             Some(Format::Tsv) => Ok(Box::new(
                 CsvToDataFrame::from_args(self).with_separator('\t'),
             )),
-            Some(Format::Parquet) => Ok(Box::new(ParquetToDataFrame)),
+            Some(Format::Parquet) => Ok(Box::new(ParquetToDataFrame::from_args(self))),
             Some(Format::Json) => Ok(Box::new(JsonToDataFrame::from_args(self))),
             Some(Format::Jsonl) => Ok(Box::new(JsonLineToDataFrame::from_args(self))),
-            Some(Format::Arrow) => Ok(Box::new(ArrowIpcToDataFrame)),
+            Some(Format::Arrow) => Ok(Box::new(ArrowIpcToDataFrame::from_args(self))),
             Some(Format::Fwf) => Ok(Box::new(FwfToDataFrame::from_args(self))),
             Some(Format::Sqlite) => Ok(Box::new(SqliteToDataFrames::from_args(self))),
             Some(Format::Excel) => Ok(Box::new(ExcelToDataFrames::from_args(self))),
             Some(Format::Logfmt) => Ok(Box::new(LogfmtToDataFrame::from_args(self))),
-            Some(Format::Avro) => Ok(Box::new(AvroToDataFrame)),
+            Some(Format::Avro) => Ok(Box::new(AvroToDataFrame::from_args(self))),
             Some(Format::Html) => Ok(Box::new(HtmlToDataFrame::from_args(self))),
             Some(Format::Markdown) => Ok(Box::new(MarkdownToDataFrame::from_args(self))),
             None => match path.as_ref().extension().and_then(|ext| ext.to_str()) {
@@ -49,11 +49,11 @@ impl BuildReader for Args {
                     let reader = CsvToDataFrame::from_args(self).with_separator('\t');
                     Ok(Box::new(reader))
                 }
-                Some("parquet") | Some("pqt") => Ok(Box::new(ParquetToDataFrame)),
+                Some("parquet") | Some("pqt") => Ok(Box::new(ParquetToDataFrame::from_args(self))),
                 Some("json") => Ok(Box::new(JsonToDataFrame::from_args(self))),
                 Some("jsonl") => Ok(Box::new(JsonLineToDataFrame::from_args(self))),
-                Some("arrow") => Ok(Box::new(ArrowIpcToDataFrame)),
-                Some("avro") => Ok(Box::new(AvroToDataFrame)),
+                Some("arrow") => Ok(Box::new(ArrowIpcToDataFrame::from_args(self))),
+                Some("avro") => Ok(Box::new(AvroToDataFrame::from_args(self))),
                 Some("fwf") => Ok(Box::new(FwfToDataFrame::from_args(self))),
                 Some("db") | Some("sqlite") => Ok(Box::new(SqliteToDataFrames::from_args(self))),
                 Some("xls") | Some("xlsx") | Some("xlsm") | Some("xlsb") => {

--- a/src/tui/popups/importers/arrow.rs
+++ b/src/tui/popups/importers/arrow.rs
@@ -24,7 +24,10 @@ impl OverlayStep for State {
         match self {
             State::PickSource { picker } => match picker.value() {
                 Some(ImportSource::Stdin) => {
-                    dismiss_overlay_and_load_data_frame(DataSource::Stdin, ArrowIpcToDataFrame);
+                    dismiss_overlay_and_load_data_frame(
+                        DataSource::Stdin,
+                        ArrowIpcToDataFrame::default(),
+                    );
                     State::PickSource { picker }
                 }
                 Some(ImportSource::File) => State::PickPath {
@@ -38,13 +41,16 @@ impl OverlayStep for State {
             State::PickPath { picker } => {
                 dismiss_overlay_and_load_data_frame(
                     DataSource::File(picker.path()),
-                    ArrowIpcToDataFrame,
+                    ArrowIpcToDataFrame::default(),
                 );
                 Default::default()
             }
             State::PickUrl { picker } => match picker.url() {
                 Ok(url) => {
-                    dismiss_overlay_and_load_data_frame(DataSource::Url(url), ArrowIpcToDataFrame);
+                    dismiss_overlay_and_load_data_frame(
+                        DataSource::Url(url),
+                        ArrowIpcToDataFrame::default(),
+                    );
                     Default::default()
                 }
                 Err(err) => {

--- a/src/tui/popups/importers/avro.rs
+++ b/src/tui/popups/importers/avro.rs
@@ -24,7 +24,10 @@ impl OverlayStep for State {
         match self {
             State::PickSource { picker } => match picker.value() {
                 Some(ImportSource::Stdin) => {
-                    dismiss_overlay_and_load_data_frame(DataSource::Stdin, AvroToDataFrame);
+                    dismiss_overlay_and_load_data_frame(
+                        DataSource::Stdin,
+                        AvroToDataFrame::default(),
+                    );
                     State::PickSource { picker }
                 }
                 Some(ImportSource::File) => State::PickPath {
@@ -38,13 +41,16 @@ impl OverlayStep for State {
             State::PickPath { picker } => {
                 dismiss_overlay_and_load_data_frame(
                     DataSource::File(picker.path()),
-                    AvroToDataFrame,
+                    AvroToDataFrame::default(),
                 );
                 Default::default()
             }
             State::PickUrl { picker } => match picker.url() {
                 Ok(url) => {
-                    dismiss_overlay_and_load_data_frame(DataSource::Url(url), AvroToDataFrame);
+                    dismiss_overlay_and_load_data_frame(
+                        DataSource::Url(url),
+                        AvroToDataFrame::default(),
+                    );
                     Default::default()
                 }
                 Err(err) => {

--- a/src/tui/popups/importers/parquet.rs
+++ b/src/tui/popups/importers/parquet.rs
@@ -24,7 +24,10 @@ impl OverlayStep for State {
         match self {
             State::PickSource { picker } => match picker.value() {
                 Some(ImportSource::Stdin) => {
-                    dismiss_overlay_and_load_data_frame(DataSource::Stdin, ParquetToDataFrame);
+                    dismiss_overlay_and_load_data_frame(
+                        DataSource::Stdin,
+                        ParquetToDataFrame::default(),
+                    );
                     State::PickSource { picker }
                 }
                 Some(ImportSource::File) => State::PickPath {
@@ -38,13 +41,16 @@ impl OverlayStep for State {
             State::PickPath { picker } => {
                 dismiss_overlay_and_load_data_frame(
                     DataSource::File(picker.path()),
-                    ParquetToDataFrame,
+                    ParquetToDataFrame::default(),
                 );
                 Default::default()
             }
             State::PickUrl { picker } => match picker.url() {
                 Ok(url) => {
-                    dismiss_overlay_and_load_data_frame(DataSource::Url(url), ParquetToDataFrame);
+                    dismiss_overlay_and_load_data_frame(
+                        DataSource::Url(url),
+                        ParquetToDataFrame::default(),
+                    );
                     Default::default()
                 }
                 Err(err) => {


### PR DESCRIPTION
Closes #115.

Tabiew loads the whole file before the TUI comes up, which is painful on multi-GB inputs. This adds a `--max-rows <N>` flag so you can preview just the first N rows, which is handy for checking the schema and a sample of the data before committing to a full load.

Where polars can limit reads natively it does, so we never materialize more than N rows: CSV/DSV/TSV via `with_n_rows`, Parquet via `with_slice`, and Arrow and Avro via `with_n_rows`. JSON and JSON Lines have no native row limit in the eager reader, so those get capped with `head` after reading. The flag defaults to unset, so behavior is unchanged when it's not passed.

Added a few unit tests on the CSV path and a note in the README.