### PR TITLE
declare rust-version 1.95

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.14.2"
 authors = ["Shayan Hashemi <shshemi@gmail.com>"]
 license = "MIT"
 edition = "2024"
+rust-version = "1.95"
 description = "A lightweight TUI application to view and query tabular data files, such as CSV, TSV, and parquet."
 repository = "https://github.com/shshemi/tabiew"
 documentation = "https://docs.rs/tabiew"

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ cargo install --locked tabiew
 
 ### Build from Source
 
-Ensure you have rustc version 1.80 (or higher) installed. Download the desired source version from the [release page](https://github.com/shshemi/tabiew/releases). Extract the downloaded file and navigate into the extracted directory. Then run the following command:
+Ensure you have rustc version 1.95 (or higher) installed. Download the desired source version from the [release page](https://github.com/shshemi/tabiew/releases). Extract the downloaded file and navigate into the extracted directory. Then run the following command:
 ```bash
 cargo build --release
 cp ./target/release/tw <system_or_local_bin_path>


### PR DESCRIPTION
Related to #113

## Summary

Declares `rust-version = "1.95"` in `Cargo.toml` and updates the README's build-from-source instructions (previously "rustc version 1.80 or higher") to match. This gap surfaced while preparing the in-place refresh contribution for #113 (opened as a companion PR from the same fork): the project failed to build in a fresh environment on an older stable toolchain, with an error that did not name the project's actual requirement.

## Why

The committed `Cargo.lock` pins `sysinfo 0.39.6`, which requires rustc 1.95. On older toolchains the build currently fails with a dependency-resolution error that names `sysinfo` rather than the project's requirement:

```
error: rustc 1.94.1 is not supported by the following package:
  sysinfo@0.39.6 requires rustc 1.95
```

With `rust-version` declared, cargo instead reports the minimum supported toolchain for the project directly, and tooling (docs.rs, `cargo add` MSRV-aware resolution in consumers, lints) can see the requirement.

## Verification

- rustc **1.94.1**: fails on `sysinfo 0.39.6` resolution (reproduced before the change)
- rustc **1.95.0**: `cargo check` passes
- rustc **1.98.1** (current stable): `cargo check --all-targets`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` all pass
- `cargo metadata` confirms `sysinfo 0.39.6` is the strictest `rust_version` among all locked dependencies (next highest is 1.88.0)

The release workflow uses `dtolnay/rust-toolchain@stable`, so CI is unaffected.